### PR TITLE
CELC-690 adding post and upload max values bumping

### DIFF
--- a/7.4/Dockerfile
+++ b/7.4/Dockerfile
@@ -72,6 +72,10 @@ RUN apt -y update \
  && echo "memory_limit=2048M" > /etc/php/7.4/apache2/conf.d/memory-limit.ini \
  && echo "extension=timecop.so" > /etc/php/7.4/cli/conf.d/20-timecop.ini \
  && echo "extension=timecop.so" > /etc/php/7.4/apache2/conf.d/20-timecop.ini \
+ && echo "upload_max_filesize=20M" > /etc/php/7.4/cli/conf.d/20-upload-limits.ini \
+ && echo "post_max_size=30M" >> /etc/php/7.4/cli/conf.d/20-upload-limits.ini \
+ && echo "upload_max_filesize=20M" > /etc/php/7.4/apache2/conf.d/20-upload-limits.ini \
+ && echo "post_max_size=30M" >> /etc/php/7.4/apache2/conf.d/20-upload-limits.ini \
 # Bashrc
  && echo "alias ls='ls --color=auto'" >> .bashrc \
  && echo "alias ll='ls -halF'" >> .bashrc \


### PR DESCRIPTION
Only 7.4 image can be built because the others are base on `debian:stretch` and https://packages.sury.org/php doesn't have a release file for this one anymore

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/lancastersolutions/docker-apachephp7/39)
<!-- Reviewable:end -->
